### PR TITLE
doc(common): add deploying dev doc

### DIFF
--- a/.github/workflows/dev-documentation.yml
+++ b/.github/workflows/dev-documentation.yml
@@ -1,0 +1,43 @@
+name: dev-documentation
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+# Мы хотим чтобы deploy в ветку gh-pages
+# происходили консистентно друг за другом
+concurrency:
+  group: deploy-docs
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    name: Deploy dev documentation
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        working-directory: documentation
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Configure Git user
+        run: |
+          git config user.email "actions@github.com"
+          git config user.name "GitHub Actions"
+      - name: Setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+          cache: 'pip'
+      - name: Download mkdocs plugins
+        run: pip install -r requirements.txt
+      - name: Deploy documentation into gh-pages branch
+        run: mike deploy dev --push
+      - name: Setup default version
+        run: mike set-default dev --push

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -1,5 +1,7 @@
 site_name: Tarantool Java SDK
 copyright: Copyright ©️ 2025 VK Tech
+repo_name: tarantool/tarantool-java-sdk
+repo_url: https://github.com/tarantool/tarantool-java-sdk
 extra:
   language: ru
   generator: false
@@ -8,6 +10,9 @@ extra:
       link: https://github.com/tarantool/tarantool-java-sdk
     - icon: tarantool/tarantool
       link: https://www.tarantool.io/ru/
+  version:
+    provider: mike
+    alias: true
 
 theme:
   features:
@@ -34,6 +39,7 @@ theme:
 
 #  favicon: images/favicon.svg
   icon:
+    repo: fontawesome/brands/github
     logo: tarantool/tarantool
     admonition:
       note: octicons/tag-16

--- a/documentation/requirements.txt
+++ b/documentation/requirements.txt
@@ -1,0 +1,2 @@
+mkdocs-material==9.7.0
+mike==v2.1.3


### PR DESCRIPTION
Add workflow to deploy develop
version of documentation

<!-- What has been done? Why? What problem is being solved? -->


I haven't forgotten about:
- [ ] Tests
- [ ] Changelog
- [ ] Documentation
  - [ ] JavaDoc was written
- [ ] Commit messages comply with the [guideline](https://www.tarantool.io/en/doc/latest/dev_guide/developer_guidelines/#how-to-write-a-commit-message)
- [ ] Cleanup the code for review. See [checklist](https://github.com/tarantool/cartridge-java/blob/master/docs/review-checklist.md)

Related issues:
<!-- Needed for #123 -->
<!-- See also #456, #789 -->
<!-- Part of #123 -->
<!-- Closes #456 -->
