### PR TITLE
chore: bump dependencies for release 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,23 +20,24 @@
 - Updated dependencies:
 
   Compile:
-    * Bump jackson version from 2.18.4 to 2.21.2
-    * Bump msgpack version from 0.9.10 to 0.9.11
-    * Bump netty version from 4.2.7.Final to 4.2.12.Final
+    * Bump jackson version from 2.18.4 to 2.21.3
+    * Bump msgpack version from 0.9.10 to 0.9.12
+    * Bump netty version from 4.2.7.Final to 4.2.13.Final
     * Bump httpclient5 version from 5.5 to 5.5.2
-    * Bump httpcore5 version from 5.3.4 to 5.3.6
+    * Bump httpcore5 version from 5.3.4 to 5.4.2
     * Bump spring-boot version from 3.5.8 to 3.5.10 in tarantool-spring-data-35
     * Pin spring-data-keyvalue version to 3.5.10 for tarantool-spring-data-35 and 4.0.4 for tarantool-spring-data-40
+    * Bump micrometer version from 1.16.4 to 1.16.5
 
   Tests:
-    * Bump testcontainers version from 2.0.1 to 2.0.4
-    * Bump junit-jupiter version from 5.13.4 to 5.14.3
+    * Bump testcontainers version from 2.0.1 to 2.0.5
+    * Bump junit-jupiter version from 5.13.4 to 5.14.4
     * Bump logback version from 1.5.21 to 1.5.32 in spring-data module
     * Bump grpc version from 1.76.0 to 1.77.0
     * Bump protobuf version from 3.25.8 to 3.25.9
     * Bump commons-io version from 2.20.0 to 2.21.0
-    * Bump commons-codec version from 1.19.0 to 1.21.0
-    * Bump opentelemetry version from 1.48.0 to 1.61.0
+    * Bump commons-codec version from 1.19.0 to 1.22.0
+    * Bump opentelemetry version from 1.48.0 to 1.62.0
 
   Maven:
     * Bump maven-enforcer-plugin from 3.6.1 to 3.6.2

--- a/pom.xml
+++ b/pom.xml
@@ -71,18 +71,18 @@
   </scm>
 
   <properties>
-    <jackson.version>2.21.2</jackson.version>
-    <msgpack.version>0.9.11</msgpack.version>
+    <jackson.version>2.21.3</jackson.version>
+    <msgpack.version>0.9.12</msgpack.version>
     <javadoc.plugin.version>3.12.0</javadoc.plugin.version>
     <logging.config>${project.basedir}/src/test/resources/logback-test.xml</logging.config>
     <logging.logLevel>debug</logging.logLevel>
     <maven.compiler.source>8</maven.compiler.source>
     <maven.compiler.target>8</maven.compiler.target>
-    <netty.version>4.2.12.Final</netty.version>
+    <netty.version>4.2.13.Final</netty.version>
     <slf4j.api.version>2.0.17</slf4j.api.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <testcontainers.version>2.0.4</testcontainers.version>
+    <testcontainers.version>2.0.5</testcontainers.version>
     <grpc.version>1.77.0</grpc.version>
     <protobuf.version>3.25.9</protobuf.version>
     <jetcd.version>0.8.6</jetcd.version>

--- a/tarantool-java-sdk-bom/pom.xml
+++ b/tarantool-java-sdk-bom/pom.xml
@@ -12,28 +12,28 @@
     <version>2.0.0-SNAPSHOT</version>
 
     <properties>
-        <jackson.version>2.21.2</jackson.version>
-        <msgpack.version>0.9.11</msgpack.version>
-        <netty.version>4.2.12.Final</netty.version>
+        <jackson.version>2.21.3</jackson.version>
+        <msgpack.version>0.9.12</msgpack.version>
+        <netty.version>4.2.13.Final</netty.version>
         <slf4j.api.version>2.0.17</slf4j.api.version>
-        <testcontainers.version>2.0.4</testcontainers.version>
+        <testcontainers.version>2.0.5</testcontainers.version>
         <logback.version>1.3.16</logback.version>
-        <junit-jupiter.version>5.14.3</junit-jupiter.version>
+        <junit-jupiter.version>5.14.4</junit-jupiter.version>
         <commons-lang3.version>3.19.0</commons-lang3.version>
         <lombok.version>1.18.44</lombok.version>
         <guava.version>33.5.0-jre</guava.version>
-        <micrometer.version>1.16.4</micrometer.version>
+        <micrometer.version>1.16.5</micrometer.version>
         <httpclient5.version>5.5.2</httpclient5.version>
-        <httpcore5.version>5.3.6</httpcore5.version>
+        <httpcore5.version>5.4.2</httpcore5.version>
         <jetcd.version>0.8.6</jetcd.version>
         <grpc.version>1.77.0</grpc.version>
         <protobuf.version>3.25.9</protobuf.version>
         <commons-compress.version>1.28.0</commons-compress.version>
-        <commons-codec.version>1.21.0</commons-codec.version>
+        <commons-codec.version>1.22.0</commons-codec.version>
         <commons-io.version>2.21.0</commons-io.version>
         <instancio.version>5.5.1</instancio.version>
         <jsonschema2pojo.version>1.2.2</jsonschema2pojo.version>
-        <opentelemetry.version>1.61.0</opentelemetry.version>
+        <opentelemetry.version>1.62.0</opentelemetry.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Bump dependencies for the next modules

  Compile:
  - jackson: 2.21.2 → 2.21.3
  - msgpack: 0.9.11 → 0.9.12
  - netty: 4.2.12.Final → 4.2.13.Final
  - httpcore5: 5.3.6 → 5.4.2
  - micrometer: 1.16.4 → 1.16.5

  Tests:
  - testcontainers: 2.0.4 → 2.0.5
  - junit-jupiter: 5.14.3 → 5.14.4
  - commons-codec: 1.21.0 → 1.22.0
  - opentelemetry: 1.61.0 → 1.62.0

I haven't forgotten about:
- [ ] Tests
- [x] Changelog
- [ ] Documentation
  - [ ] JavaDoc was written
- [x] Commit messages comply with the [guideline](https://www.tarantool.io/en/doc/latest/dev_guide/developer_guidelines/#how-to-write-a-commit-message)
- [x] Cleanup the code for review. See [checklist](https://github.com/tarantool/cartridge-java/blob/master/docs/review-checklist.md)

Related issues:
<!-- Needed for #123 -->
<!-- See also #456, #789 -->
<!-- Part of #123 -->
<!-- Closes #456 -->
