### PR TITLE
Improve release process

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       releaseVersion:
-        description: 'Release and tag version'
+        description: 'Release version (e.g., 2.0.0, 2.0.0-M1, 2.0.0-RC1)'
         required: true
-        default: "1.5.0"
+        default: "2.0.0"
       developmentVersion:
         description: 'Version to use for new working copy'
         required: true
@@ -32,6 +32,16 @@ jobs:
         run: |
           git config user.email "actions@github.com"
           git config user.name "GitHub Actions"
+
+      - name: Validate version format
+        run: |
+          VERSION="${{ github.event.inputs.releaseVersion }}"
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-M[0-9]+|-RC[0-9]+)?$ ]]; then
+            echo "Error: Version '$VERSION' does not match valid pattern"
+            echo "Expected formats: X.Y.Z, X.Y.Z-MN, or X.Y.Z-RCN"
+            exit 1
+          fi
+          echo "Version '$VERSION' is valid"
 
       - name: Run release release.yml
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,11 +3,13 @@ name: Publish Release to Maven Central
 on:
   push:
     tags:
-      - '*'
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+-M[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+-RC[0-9]+'
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag to checkout and publish'
+        description: 'Tag to checkout and publish (e.g., 2.0.0, 2.0.0-M1, 2.0.0-RC1)'
         required: true
         type: string
 
@@ -19,6 +21,16 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ inputs.tag }}
+
+      - name: Validate tag format
+        run: |
+          TAG="${{ github.ref_name || inputs.tag }}"
+          if [[ ! "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-M[0-9]+|-RC[0-9]+)?$ ]]; then
+            echo "Error: Tag '$TAG' does not match valid version pattern"
+            echo "Expected formats: X.Y.Z, X.Y.Z-MN, or X.Y.Z-RCN"
+            exit 1
+          fi
+          echo "Tag '$TAG' is valid"
 
       - name: Set up JDK 17
         uses: actions/setup-java@v5

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,5 +1,18 @@
 # Release Process for Tarantool Java SDK
 
+## Version Types
+
+We use the following version formats:
+
+| Type | Format | Example | Description |
+|------|--------|---------|-------------|
+| Final Release | `X.Y.Z` | `2.0.0` | Production-ready release |
+| Milestone | `X.Y.Z-MN` | `2.0.0-M1` | Early preview for testing |
+| Release Candidate | `X.Y.Z-RCN` | `2.0.0-RC1` | Pre-release for final validation |
+| Development | `X.Y.Z-dev.N` | `2.0.0-dev.1` | Internal development builds (not for Maven Central) |
+
+## Release Steps
+
 Follow these steps to prepare and publish a new release:
 
 1. **Update JavaDoc and Project Documentation**
@@ -20,7 +33,9 @@ Follow these steps to prepare and publish a new release:
 
 4. **Run the "Prepare Release" Workflow**
     - After the PR is merged, trigger the "Prepare Release" workflow (using Maven Release Plugin) to prepare the release.
+    - Enter the release version (e.g., `2.0.0`, `2.0.0-M1`, or `2.0.0-RC1`) and the next development version.
     - This will update versions, tag the release, and push changes to the repository.
+    - **For Milestones and RCs**: The tag will trigger the release workflow automatically. After publishing to Maven Central, mark the GitHub release as "Pre-release".
 
 5. **Publish Artifacts to Maven Central**
     - Once the workflow completes successfully, go to Maven Central and publish the release from the service account.

--- a/pom.xml
+++ b/pom.xml
@@ -64,9 +64,9 @@
   </developers>
 
   <scm>
-    <connection>scm:git:https://github.com/tarantool/tarantool-java-sdk.git</connection>
-    <developerConnection>scm:git:https://github.com/tarantool/tarantool-java-sdk.git</developerConnection>
-    <url>scm:git:https://github.com/tarantool/tarantool-java-sdk.git</url>
+    <connection>scm:git:git@github.com:tarantool/tarantool-java-sdk.git</connection>
+    <developerConnection>scm:git:git@github.com:tarantool/tarantool-java-sdk.git</developerConnection>
+    <url>https://github.com/tarantool/tarantool-java-sdk.git</url>
     <tag>HEAD</tag>
   </scm>
 


### PR DESCRIPTION
Add support for publishing milestone (M) and release candidate (RC)
versions to Maven Central:

- Update release.yml tag patterns to accept X.Y.Z-MN and X.Y.Z-RCN
- Add version validation steps to release workflows
- Update RELEASING.md with version types table

Change maven-release-plugin to use SSH URL instead of HTTPS for
pushing commits to protected master branch.


I haven't forgotten about:
- [ ] Tests
- [ ] Changelog
- [ ] Documentation
  - [ ] JavaDoc was written
- [x] Commit messages comply with the [guideline](https://www.tarantool.io/en/doc/latest/dev_guide/developer_guidelines/#how-to-write-a-commit-message)
- [x] Cleanup the code for review. See [checklist](https://github.com/tarantool/cartridge-java/blob/master/docs/review-checklist.md)

Related issues:
<!-- Needed for #123 -->
<!-- See also #456, #789 -->
<!-- Part of #123 -->
<!-- Closes #456 -->
