### PR TITLE
refactor(testcontainers): extract ObjectMapper to static field in tdg.Utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   surface into a single parameterized suite.
 - Add constructor/builder parameters to supply the initial Lua script as a string or as a file path, and optional additional script paths copied into the container data directory (`Tarantool2Container`, `CartridgeClusterContainer`, `VshardClusterContainer`); simplify bundled `server.lua` accordingly.
 - Upgrade TQE to v3.5.0.
+- Extract `ObjectMapper` to a static field in the test `tdg.Utils` helper to avoid recreating it on every `sendUsers`/`getUsers` call.
 
 ### Documentation
 

--- a/testcontainers/src/test/java/org/testcontainers/containers/tdg/Utils.java
+++ b/testcontainers/src/test/java/org/testcontainers/containers/tdg/Utils.java
@@ -25,15 +25,16 @@ import org.testcontainers.containers.utils.pojo.User;
 
 public abstract class Utils {
 
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
   private Utils() {}
 
   public static List<User> sendUsers(List<User> users, TDGContainer<?> container)
       throws IOException {
     final List<User> result = new ArrayList<>();
-    final ObjectMapper objectMapper = new ObjectMapper();
     try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
       for (final User user : users) {
-        final String jsonUser = objectMapper.writeValueAsString(user);
+        final String jsonUser = OBJECT_MAPPER.writeValueAsString(user);
         final String address = HttpHost.unsecure(container.httpMappedAddress()) + "/data/User";
         final HttpPost post = new HttpPost(address);
         final HttpEntity entity = new StringEntity(jsonUser, ContentType.APPLICATION_JSON);
@@ -50,7 +51,7 @@ public abstract class Utils {
                             + ", "
                             + response.getReasonPhrase());
                   }
-                  return objectMapper.readValue(
+                  return OBJECT_MAPPER.readValue(
                       EntityUtils.toString(response.getEntity()), User.class);
                 }));
       }
@@ -59,7 +60,6 @@ public abstract class Utils {
   }
 
   public static List<User> getUsers(int count, TDGContainer<?> node) throws IOException {
-    final ObjectMapper objectMapper = new ObjectMapper();
     try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
       final String address =
           HttpHost.unsecure(node.httpMappedAddress()) + "/data/User?first=" + count;
@@ -73,7 +73,7 @@ public abstract class Utils {
                       + ", "
                       + response.getReasonPhrase());
             }
-            return objectMapper.readValue(
+            return OBJECT_MAPPER.readValue(
                 EntityUtils.toString(response.getEntity()), new TypeReference<List<User>>() {});
           });
     }


### PR DESCRIPTION
Hoist the `ObjectMapper` instance used by the test helper
`org.testcontainers.containers.tdg.Utils` from a method-local variable to
a `static final` field.

`ObjectMapper` instances are thread-safe once configured, so the previous
`new ObjectMapper()` allocations in `sendUsers(List<User>, TDGContainer<?>)`
and `getUsers(int, TDGContainer<?>)` were unnecessary and duplicated.
Extracting the instance:

- removes the per-call allocation and the duplicated `new ObjectMapper()`
  call sites;
- keeps the mapper in a single, clearly named place (`OBJECT_MAPPER`),
  matching the UPPER_SNAKE_CASE convention for `static final` fields;
- makes future configuration of the mapper (modules, features) a
  one-line change in a single spot instead of two.

This is a test-only refactor — `Utils` lives under `src/test/java` and is
not part of the published artifact, so there is no API or behavior change
for SDK consumers.

I haven't forgotten about:
- [x] Tests
- [x] Changelog
- [ ] Documentation
  - [ ] JavaDoc was written
- [x] Commit messages comply with the [guideline](https://www.tarantool.io/en/doc/latest/dev_guide/developer_guidelines/#how-to-write-a-commit-message)
- [x] Cleanup the code for review. See [checklist](https://github.com/tarantool/cartridge-java/blob/master/docs/review-checklist.md)
