### PR TITLE
fix(pooling): fix race conditions, deadlock, and connection leak in PoolEntry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@
 ### Pooling
 
 - Fix race conditions, ABBA deadlock between `PoolEntry` and `ConnectionImpl` monitors, NPE on inline connect failure, and connection leak after a KILL/reconnect cycle in `PoolEntry` and `IProtoClientPoolImpl`.
-- Synchronize `IProtoClientPoolImpl.forEach()` on the pool lock to avoid `ConcurrentModificationException` under concurrent `setGroups()`.
 
 ### Dependencies
 - Updated dependencies:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@
 - Document supported Java types for Tarantool data mapping in `tuple_pojo_mapping` docs (RU/EN), including Tarantool extension types (`decimal`, `uuid`, `datetime`, `interval`, `tuple`) and related mapping notes.
 - Document Jackson MsgPack deserialization: integers, `bin`/`str` vs `byte[]`/`String`, floating-point vs `decimal`; reference `jackson-dataformat-msgpack` for defaults and type coercion.
 
+### Pooling
+
+- Fix race conditions, ABBA deadlock between `PoolEntry` and `ConnectionImpl` monitors, NPE on inline connect failure, and connection leak after a KILL/reconnect cycle in `PoolEntry` and `IProtoClientPoolImpl`.
+- Synchronize `IProtoClientPoolImpl.forEach()` on the pool lock to avoid `ConcurrentModificationException` under concurrent `setGroups()`.
+
 ### Dependencies
 - Updated dependencies:
 

--- a/tarantool-pooling/src/main/java/io/tarantool/pool/IProtoClientPoolImpl.java
+++ b/tarantool-pooling/src/main/java/io/tarantool/pool/IProtoClientPoolImpl.java
@@ -524,9 +524,11 @@ public class IProtoClientPoolImpl implements IProtoClientPool {
 
   @Override
   public void forEach(Consumer<IProtoClient> action) {
-    for (List<PoolEntry> group : entries.values()) {
-      for (PoolEntry entry : group) {
-        action.accept(entry.getClient());
+    synchronized (connectionPoolLock) {
+      for (List<PoolEntry> group : entries.values()) {
+        for (PoolEntry entry : group) {
+          action.accept(entry.getClient());
+        }
       }
     }
   }

--- a/tarantool-pooling/src/main/java/io/tarantool/pool/IProtoClientPoolImpl.java
+++ b/tarantool-pooling/src/main/java/io/tarantool/pool/IProtoClientPoolImpl.java
@@ -524,13 +524,15 @@ public class IProtoClientPoolImpl implements IProtoClientPool {
 
   @Override
   public void forEach(Consumer<IProtoClient> action) {
+    List<IProtoClient> clients = new ArrayList<>();
     synchronized (connectionPoolLock) {
       for (List<PoolEntry> group : entries.values()) {
         for (PoolEntry entry : group) {
-          action.accept(entry.getClient());
+          clients.add(entry.getClient());
         }
       }
     }
+    clients.forEach(action);
   }
 
   /**

--- a/tarantool-pooling/src/main/java/io/tarantool/pool/PoolEntry.java
+++ b/tarantool-pooling/src/main/java/io/tarantool/pool/PoolEntry.java
@@ -8,6 +8,7 @@ package io.tarantool.pool;
 import java.util.ArrayDeque;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -146,16 +147,16 @@ final class PoolEntry {
   private CompletableFuture<IProtoClient> connectFuture;
 
   /** Last heartbeat state/event. */
-  private HeartbeatEvent lastHeartbeatEvent;
+  private volatile HeartbeatEvent lastHeartbeatEvent;
 
   /** Heartbeat timer/task. */
-  private Timeout heartbeatTask;
+  private volatile Timeout heartbeatTask;
 
   /** Reconnection task. */
   private Timeout reconnectTask;
 
   /** Flag signaling if heartbeat started or not. */
-  private boolean isHeartbeatStarted;
+  private volatile boolean isHeartbeatStarted;
 
   /**
    * Flag signaling if connection is available or not.
@@ -163,7 +164,16 @@ final class PoolEntry {
    * <p>When connection comes to invalidated state or killed, pool entry is locked and connection
    * will not be returned to outer client.
    */
-  private boolean isLocked;
+  private volatile boolean isLocked;
+
+  /**
+   * Idempotency flag for {@link #shutdown()}.
+   *
+   * <p>Guarantees that the close listener is invoked only once even if both {@link #close()} and
+   * {@link #shutdown()} are called, or shutdown is invoked multiple times due to overlapping
+   * connection error events.
+   */
+  private final AtomicBoolean isShutdown = new AtomicBoolean(false);
 
   /** Count of failed pings occurred in invalidated state. */
   private int currentDeathPings;
@@ -305,7 +315,7 @@ final class PoolEntry {
    *
    * <p>Also increments count of unavailable clients.
    */
-  public void lock() {
+  public synchronized void lock() {
     if (!isLocked) {
       unavailable.incrementAndGet();
       isLocked = true;
@@ -317,7 +327,7 @@ final class PoolEntry {
    *
    * <p>Also decrements count of unavailable clients and cancels reconnect task.
    */
-  public void unlock() {
+  public synchronized void unlock() {
     if (isLocked) {
       stopReconnectTask();
       unavailable.decrementAndGet();
@@ -340,16 +350,28 @@ final class PoolEntry {
     shutdown();
   }
 
-  /** Closes client and stops heartbeat task is started. */
+  /**
+   * Closes the underlying client and stops the heartbeat task.
+   *
+   * <p>Performs field mutations under the entry monitor, then releases it before calling {@code
+   * client.close()} (which acquires the {@code ConnectionImpl} monitor) and emitting the close
+   * event. Holding the entry monitor across either of those calls would create an ABBA deadlock
+   * with the Netty close-callback path, which takes the {@code ConnectionImpl} monitor first and
+   * then re-enters {@link #handleConnectError(Object, Throwable)} on the entry.
+   */
   public void shutdown() {
-    connectFuture = null;
-    stopHeartbeat();
+    synchronized (this) {
+      connectFuture = null;
+      stopHeartbeat();
+    }
     try {
       client.close();
     } catch (Exception e) {
       log.warn("Cannot close client in pool", e);
     }
-    emit(listener -> listener.onConnectionClosed(tag, index));
+    if (isShutdown.compareAndSet(false, true)) {
+      emit(listener -> listener.onConnectionClosed(tag, index));
+    }
   }
 
   /**
@@ -410,15 +432,27 @@ final class PoolEntry {
   /**
    * Internal method used by reconnect task and public connect.
    *
+   * <p>Returns the local chain {@code cf} rather than the {@link #connectFuture} field. If the
+   * underlying {@code client.connect()} fails inline (e.g. connection refused), the {@code
+   * whenComplete} callback fires reentrantly on the calling thread, which causes {@link
+   * #handleConnectError(Object, Throwable)} to clear the field for reconnect purposes. The local
+   * variable still references the (failed) future, so callers always receive a non-null result and
+   * observe the failure via {@code ExecutionException} from {@code .get()}, while the field being
+   * null guarantees that the next reconnect attempt actually reconnects instead of returning a
+   * stale failed future.
+   *
    * @return {@link java.util.concurrent.CompletableFuture} with client
    */
-  private CompletableFuture<IProtoClient> internalConnect() {
+  private synchronized CompletableFuture<IProtoClient> internalConnect() {
+    if (connectFuture != null) {
+      return connectFuture;
+    }
     log.info("connect {}/{}", tag, index);
     LongTaskTimer.Sample timer = startTimer(connectTime);
     CompletableFuture<?> future =
         client.connect(group.getAddress(), connectTimeout, gracefulShutdown);
     String user = group.getUser();
-    connectFuture =
+    CompletableFuture<IProtoClient> cf =
         future
             .thenCompose(
                 greeting -> {
@@ -428,9 +462,10 @@ final class PoolEntry {
                   }
                   return client.ping(firstPingOpts);
                 })
-            .thenApply(r -> client)
-            .whenComplete(this::onConnectComplete);
-    return connectFuture;
+            .thenApply(r -> client);
+    connectFuture = cf;
+    cf.whenComplete(this::onConnectComplete);
+    return cf;
   }
 
   /**
@@ -462,6 +497,10 @@ final class PoolEntry {
   /**
    * Handler for connection close.
    *
+   * <p>The {@code connectFuture} reset is performed under this monitor; emit, {@link #lock()},
+   * {@link #shutdown()} and {@link #connectAfter()} run outside it (see {@link #shutdown()} for
+   * why).
+   *
    * @param r connection instance
    * @param exc exception which led to connection close
    */
@@ -470,7 +509,9 @@ final class PoolEntry {
       return;
     }
     Throwable failure = exc.getCause() != null ? exc.getCause() : exc;
-    connectFuture = null;
+    synchronized (this) {
+      connectFuture = null;
+    }
     log.error("connect error {}/{}: {}", tag, index, failure.toString());
     emit(listener -> listener.onConnectionFailed(tag, index, failure));
     lock();
@@ -480,13 +521,19 @@ final class PoolEntry {
 
   /** Reconnect task scheduler. */
   private void connectAfter() {
-    log.info("reconnect {}/{} after {} ms", tag, index, reconnectAfter);
-    if (reconnectTask == null) {
-      reconnecting.incrementAndGet();
+    synchronized (this) {
+      log.info("reconnect {}/{} after {} ms", tag, index, reconnectAfter);
+      if (reconnectTask != null) {
+        // existing task is being replaced; the existing increment in `reconnecting` carries over
+        // to the new task, so no counter change is needed here.
+        reconnectTask.cancel();
+      } else {
+        reconnecting.incrementAndGet();
+      }
+      reconnectTask =
+          timerService.newTimeout(
+              timeout -> internalConnect(), reconnectAfter, TimeUnit.MILLISECONDS);
     }
-    reconnectTask =
-        timerService.newTimeout(
-            timeout -> internalConnect(), reconnectAfter, TimeUnit.MILLISECONDS);
     emit(listener -> listener.onReconnectScheduled(tag, index, reconnectAfter));
   }
 
@@ -658,7 +705,7 @@ final class PoolEntry {
   }
 
   /** Stops reconnecting task if it is active. */
-  private void stopReconnectTask() {
+  private synchronized void stopReconnectTask() {
     if (reconnectTask != null) {
       reconnecting.decrementAndGet();
       reconnectTask.cancel();

--- a/tarantool-pooling/src/main/java/io/tarantool/pool/PoolEntry.java
+++ b/tarantool-pooling/src/main/java/io/tarantool/pool/PoolEntry.java
@@ -164,7 +164,7 @@ final class PoolEntry {
    * <p>When connection comes to invalidated state or killed, pool entry is locked and connection
    * will not be returned to outer client.
    */
-  private volatile boolean isLocked;
+  private final AtomicBoolean isLocked = new AtomicBoolean(false);
 
   /**
    * Per-generation idempotency flag for {@link #shutdown()} close-event emit; reset in {@link
@@ -280,7 +280,6 @@ final class PoolEntry {
     this.gracefulShutdown = gracefulShutdown;
     this.group = group;
     this.index = index;
-    this.isLocked = false;
     this.reconnectAfter = reconnectAfter;
     this.tag = group.getTag();
     this.timerService = timerService;
@@ -308,27 +307,63 @@ final class PoolEntry {
   }
 
   /**
-   * Method for locking pool entry.
+   * Locks the pool entry and increments the pool-wide {@code unavailable} counter on the {@code
+   * false → true} transition of {@link #isLocked}.
    *
-   * <p>Also increments count of unavailable clients.
+   * <p>All callers run on Netty IO threads:
+   *
+   * <ul>
+   *   <li>{@code ConnectFailure} — initial connect attempt fails; reaches this method via {@link
+   *       #handleConnectError(Object, Throwable)} from the {@code CLOSE_BY_REMOTE} or {@code
+   *       CLOSE_BY_SHUTDOWN} listener registered on {@link #client}.
+   *   <li>{@code ConnectionBreak} — an established connection is closed by the remote side or shut
+   *       down locally; same path as {@code ConnectFailure}.
+   *   <li>{@code HeartbeatInvalidate} — the sliding-window failure rate in {@link #pong} crosses
+   *       the invalidation threshold; reaches this method via {@link #fire(HeartbeatEvent)} for
+   *       {@code INVALIDATE}.
+   * </ul>
+   *
+   * <p>{@code ConnectionBreak} and {@code HeartbeatInvalidate} can fire concurrently (the heartbeat
+   * decides to invalidate the connection at the same instant the close callback runs). The {@link
+   * AtomicBoolean#compareAndSet} on {@link #isLocked} ensures only one of the two callers wins the
+   * {@code false → true} transition, so {@code unavailable} is incremented at most once per lock
+   * acquisition.
    */
-  public synchronized void lock() {
-    if (!isLocked) {
+  public void lock() {
+    if (isLocked.compareAndSet(false, true)) {
       unavailable.incrementAndGet();
-      isLocked = true;
     }
   }
 
   /**
-   * Method for unlocking pool entry.
+   * Unlocks the pool entry, cancels any pending reconnect task, and decrements the pool-wide {@code
+   * unavailable} counter on the {@code true → false} transition of {@link #isLocked}.
    *
-   * <p>Also decrements count of unavailable clients and cancels reconnect task.
+   * <p>Callers:
+   *
+   * <ul>
+   *   <li>{@code HeartbeatResponse} — Netty IO thread, {@link #pong} reports a healthy response and
+   *       {@link #fire(HeartbeatEvent)} for {@code ACTIVATE} reaches this method.
+   *   <li>{@code ConnectSuccess} — Netty IO thread, {@link #onConnectComplete} reaches this method
+   *       after a successful connect (and {@link #startHeartbeat}).
+   *   <li>{@code UserConfigChange} — user code, when {@code pool.setGroups(...)} shrinks a group.
+   *       Runs on the user thread while it holds {@code connectionPoolLock} (see {@code
+   *       IProtoClientPoolImpl#shrinkGroup}); that lock serialises this path against other pool
+   *       mutators, which is the only reason it is safe for user code to call {@code unlock()}
+   *       directly — no other user-code path reaches this method. Rare in practice; not driven by
+   *       Netty.
+   * </ul>
+   *
+   * <p>{@code HeartbeatResponse} and {@code ConnectSuccess} cannot run at the same time for the
+   * same entry: the heartbeat is started only after a successful connect, and {@code
+   * HeartbeatResponse} only follows a prior {@code HeartbeatInvalidate} that already locked the
+   * entry. The {@link AtomicBoolean#compareAndSet} ensures only one of possibly several concurrent
+   * unlockers runs {@link #stopReconnectTask} and decrements {@code unavailable}.
    */
-  public synchronized void unlock() {
-    if (isLocked) {
+  public void unlock() {
+    if (isLocked.compareAndSet(true, false)) {
       stopReconnectTask();
       unavailable.decrementAndGet();
-      isLocked = false;
     }
   }
 
@@ -338,7 +373,7 @@ final class PoolEntry {
    * @return {@link #isLocked} value.
    */
   public boolean isLocked() {
-    return isLocked;
+    return isLocked.get();
   }
 
   /** Closes client and stops heartbeat and reconnect tasks if started. */
@@ -355,6 +390,24 @@ final class PoolEntry {
    * event. Holding the entry monitor across either of those calls would create an ABBA deadlock
    * with the Netty close-callback path, which takes the {@code ConnectionImpl} monitor first and
    * then re-enters {@link #handleConnectError(Object, Throwable)} on the entry.
+   *
+   * <p>Callers:
+   *
+   * <ul>
+   *   <li>{@code PoolClose} — user code, via {@code pool.close()} → {@link #close()} → this method.
+   *       Runs on the user thread that closes the pool.
+   *   <li>{@code ConnectError} — Netty IO thread, via {@link #handleConnectError(Object,
+   *       Throwable)} which fires for both {@code ConnectFailure} (initial connect fails) and
+   *       {@code ConnectionBreak} (established connection drops). Runs on the Netty IO thread
+   *       delivering the close event.
+   *   <li>{@code HeartbeatKill} — Netty IO thread, via {@link #fire(HeartbeatEvent)} for {@code
+   *       KILL} when the death-ping counter crosses the death threshold. Runs on the Netty IO
+   *       thread processing the heartbeat pong.
+   * </ul>
+   *
+   * <p>The {@code isShutdown} {@link AtomicBoolean} guard on the {@code onConnectionClosed} emit
+   * makes the listener invocation one-shot regardless of how many of the above paths reach this
+   * method for the same entry.
    */
   public void shutdown() {
     synchronized (this) {

--- a/tarantool-pooling/src/main/java/io/tarantool/pool/PoolEntry.java
+++ b/tarantool-pooling/src/main/java/io/tarantool/pool/PoolEntry.java
@@ -167,11 +167,13 @@ final class PoolEntry {
   private volatile boolean isLocked;
 
   /**
-   * Idempotency flag for {@link #shutdown()}.
+   * Idempotency flag for {@link #shutdown()}, scoped to a single connection generation.
    *
-   * <p>Guarantees that the close listener is invoked only once even if both {@link #close()} and
-   * {@link #shutdown()} are called, or shutdown is invoked multiple times due to overlapping
-   * connection error events.
+   * <p>Guarantees that the close listener is invoked only once per generation even if both {@link
+   * #close()} and {@link #shutdown()} are called, or shutdown is invoked multiple times due to
+   * overlapping connection error events. It is reset in {@link #internalConnect()} when a new
+   * connection generation begins, so a KILL/reconnect cycle still emits one {@code
+   * onConnectionClosed} per generation.
    */
   private final AtomicBoolean isShutdown = new AtomicBoolean(false);
 
@@ -379,10 +381,7 @@ final class PoolEntry {
    *
    * @return {@link java.util.concurrent.CompletableFuture} with client
    */
-  public synchronized CompletableFuture<IProtoClient> connect() {
-    if (connectFuture != null) {
-      return connectFuture;
-    }
+  public CompletableFuture<IProtoClient> connect() {
     return internalConnect();
   }
 
@@ -432,20 +431,21 @@ final class PoolEntry {
   /**
    * Internal method used by reconnect task and public connect.
    *
-   * <p>Returns the local chain {@code cf} rather than the {@link #connectFuture} field. If the
-   * underlying {@code client.connect()} fails inline (e.g. connection refused), the {@code
-   * whenComplete} callback fires reentrantly on the calling thread, which causes {@link
-   * #handleConnectError(Object, Throwable)} to clear the field for reconnect purposes. The local
-   * variable still references the (failed) future, so callers always receive a non-null result and
-   * observe the failure via {@code ExecutionException} from {@code .get()}, while the field being
-   * null guarantees that the next reconnect attempt actually reconnects instead of returning a
-   * stale failed future.
+   * <p>The {@code client.connect()} chain is built without holding the entry monitor: holding it
+   * across {@code client.connect()} (which takes the {@code ConnectionImpl} monitor) would create
+   * an ABBA deadlock with the Netty close-callback path, which takes the {@code ConnectionImpl}
+   * monitor first and then re-enters {@link #handleConnectError(Object, Throwable)} on the entry.
+   * Concurrent callers are de-duplicated via the {@link #connectFuture} field; if two threads race
+   * past the first check, the second {@code client.connect()} is a no-op because {@code
+   * ConnectionImpl.connect()} only opens a channel on a {@code CLOSED -> CONNECTING} transition.
    *
    * @return {@link java.util.concurrent.CompletableFuture} with client
    */
-  private synchronized CompletableFuture<IProtoClient> internalConnect() {
-    if (connectFuture != null) {
-      return connectFuture;
+  private CompletableFuture<IProtoClient> internalConnect() {
+    synchronized (this) {
+      if (connectFuture != null) {
+        return connectFuture;
+      }
     }
     log.info("connect {}/{}", tag, index);
     LongTaskTimer.Sample timer = startTimer(connectTime);
@@ -463,7 +463,15 @@ final class PoolEntry {
                   return client.ping(firstPingOpts);
                 })
             .thenApply(r -> client);
-    connectFuture = cf;
+    synchronized (this) {
+      if (connectFuture != null) {
+        // ponytail: lost the race; ConnectionImpl's CLOSED->CONNECTING CAS already de-duped the
+        // channel, so our `cf` wraps the same promise and is safely discarded.
+        return connectFuture;
+      }
+      connectFuture = cf;
+      isShutdown.set(false);
+    }
     cf.whenComplete(this::onConnectComplete);
     return cf;
   }

--- a/tarantool-pooling/src/main/java/io/tarantool/pool/PoolEntry.java
+++ b/tarantool-pooling/src/main/java/io/tarantool/pool/PoolEntry.java
@@ -167,13 +167,8 @@ final class PoolEntry {
   private volatile boolean isLocked;
 
   /**
-   * Idempotency flag for {@link #shutdown()}, scoped to a single connection generation.
-   *
-   * <p>Guarantees that the close listener is invoked only once per generation even if both {@link
-   * #close()} and {@link #shutdown()} are called, or shutdown is invoked multiple times due to
-   * overlapping connection error events. It is reset in {@link #internalConnect()} when a new
-   * connection generation begins, so a KILL/reconnect cycle still emits one {@code
-   * onConnectionClosed} per generation.
+   * Per-generation idempotency flag for {@link #shutdown()} close-event emit; reset in {@link
+   * #internalConnect()} when a new connection generation begins.
    */
   private final AtomicBoolean isShutdown = new AtomicBoolean(false);
 
@@ -431,13 +426,8 @@ final class PoolEntry {
   /**
    * Internal method used by reconnect task and public connect.
    *
-   * <p>The {@code client.connect()} chain is built without holding the entry monitor: holding it
-   * across {@code client.connect()} (which takes the {@code ConnectionImpl} monitor) would create
-   * an ABBA deadlock with the Netty close-callback path, which takes the {@code ConnectionImpl}
-   * monitor first and then re-enters {@link #handleConnectError(Object, Throwable)} on the entry.
-   * Concurrent callers are de-duplicated via the {@link #connectFuture} field; if two threads race
-   * past the first check, the second {@code client.connect()} is a no-op because {@code
-   * ConnectionImpl.connect()} only opens a channel on a {@code CLOSED -> CONNECTING} transition.
+   * <p>See {@link #shutdown()} for the monitor-ordering reasoning; {@code client.connect()} runs
+   * outside the entry monitor for the same reason.
    *
    * @return {@link java.util.concurrent.CompletableFuture} with client
    */
@@ -465,8 +455,6 @@ final class PoolEntry {
             .thenApply(r -> client);
     synchronized (this) {
       if (connectFuture != null) {
-        // ponytail: lost the race; ConnectionImpl's CLOSED->CONNECTING CAS already de-duped the
-        // channel, so our `cf` wraps the same promise and is safely discarded.
         return connectFuture;
       }
       connectFuture = cf;
@@ -504,10 +492,6 @@ final class PoolEntry {
 
   /**
    * Handler for connection close.
-   *
-   * <p>The {@code connectFuture} reset is performed under this monitor; emit, {@link #lock()},
-   * {@link #shutdown()} and {@link #connectAfter()} run outside it (see {@link #shutdown()} for
-   * why).
    *
    * @param r connection instance
    * @param exc exception which led to connection close

--- a/tarantool-pooling/src/main/java/io/tarantool/pool/PoolEntry.java
+++ b/tarantool-pooling/src/main/java/io/tarantool/pool/PoolEntry.java
@@ -566,8 +566,8 @@ final class PoolEntry {
 
   /** Reconnect task scheduler. */
   private void connectAfter() {
+    log.info("reconnect {}/{} after {} ms", tag, index, reconnectAfter);
     synchronized (this) {
-      log.info("reconnect {}/{} after {} ms", tag, index, reconnectAfter);
       if (reconnectTask != null) {
         // existing task is being replaced; the existing increment in `reconnecting` carries over
         // to the new task, so no counter change is needed here.

--- a/tarantool-pooling/src/test/java/io/tarantool/pool/integration/BasePoolTest.java
+++ b/tarantool-pooling/src/test/java/io/tarantool/pool/integration/BasePoolTest.java
@@ -15,6 +15,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ThreadLocalRandom;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import io.micrometer.core.instrument.Counter;
@@ -93,10 +94,21 @@ public class BasePoolTest {
 
   protected int getActiveConnectionsCount(TarantoolContainer<?> tt) {
     try {
-      List<? extends Object> result =
-          TarantoolContainerClientHelper.executeCommandDecoded(
-              tt, "return box.stat.net().CONNECTIONS.current");
-      return (Integer) result.get(0) - 1;
+      // box.stat.net().CONNECTIONS.current is updated asynchronously by the IProto
+      // worker; when many connections are opened in a burst it lags behind by
+      // 100-500 ms. Wait for it to stabilise (fiber.sleep yields the worker so it
+      // can accept the pending connections) before reading the value.
+      String lua =
+          "local last = box.stat.net().CONNECTIONS.current;"
+              + " for i = 1, 50 do"
+              + " require('fiber').sleep(0.05);"
+              + " local cur = box.stat.net().CONNECTIONS.current;"
+              + " if cur == last then return cur - 1 end;"
+              + " last = cur;"
+              + " end;"
+              + " return last - 1";
+      List<? extends Object> result = TarantoolContainerClientHelper.executeCommandDecoded(tt, lua);
+      return (Integer) result.get(0);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
@@ -104,6 +116,28 @@ public class BasePoolTest {
 
   protected int getActiveConnectionsCountDelta(TarantoolContainer<?> tt, int baseline) {
     return getActiveConnectionsCount(tt) - baseline;
+  }
+
+  /**
+   * Asserts that the active connection count on the given Tarantool container reaches {@code
+   * expected}, retrying until it does. The IProto worker updates {@code
+   * box.stat.net().CONNECTIONS.current} asynchronously, and closing administrative connections
+   * (e.g. the {@code net.box} connection used by {@code executeCommandDecoded}) is asynchronous on
+   * the server, so a single read can briefly observe a stale or transitional value. Retrying the
+   * assert lets the worker converge on the final value.
+   *
+   * @param tt the Tarantool container under test
+   * @param expected the expected number of active connections
+   */
+  protected void waitForActiveConnections(TarantoolContainer<?> tt, int expected) {
+    try {
+      waitFor(
+          "Active connections count never reached " + expected,
+          Duration.ofSeconds(10),
+          () -> assertEquals(expected, getActiveConnectionsCount(tt)));
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
   }
 
   protected MeterRegistry createMetricsRegistry() {

--- a/tarantool-pooling/src/test/java/io/tarantool/pool/integration/BasePoolTest.java
+++ b/tarantool-pooling/src/test/java/io/tarantool/pool/integration/BasePoolTest.java
@@ -94,10 +94,8 @@ public class BasePoolTest {
 
   protected int getActiveConnectionsCount(TarantoolContainer<?> tt) {
     try {
-      // box.stat.net().CONNECTIONS.current is updated asynchronously by the IProto
-      // worker; when many connections are opened in a burst it lags behind by
-      // 100-500 ms. Wait for it to stabilise (fiber.sleep yields the worker so it
-      // can accept the pending connections) before reading the value.
+      // box.stat.net().CONNECTIONS.current is updated asynchronously by the IProto worker;
+      // the loop's fiber.sleep lets it drain pending connections before we read.
       String lua =
           "local last = box.stat.net().CONNECTIONS.current;"
               + " for i = 1, 50 do"
@@ -119,12 +117,8 @@ public class BasePoolTest {
   }
 
   /**
-   * Asserts that the active connection count on the given Tarantool container reaches {@code
-   * expected}, retrying until it does. The IProto worker updates {@code
-   * box.stat.net().CONNECTIONS.current} asynchronously, and closing administrative connections
-   * (e.g. the {@code net.box} connection used by {@code executeCommandDecoded}) is asynchronous on
-   * the server, so a single read can briefly observe a stale or transitional value. Retrying the
-   * assert lets the worker converge on the final value.
+   * Retries {@link #getActiveConnectionsCount} until it equals {@code expected} — see there for why
+   * a single read is unreliable.
    *
    * @param tt the Tarantool container under test
    * @param expected the expected number of active connections

--- a/tarantool-pooling/src/test/java/io/tarantool/pool/integration/ConnectionPoolReconnectsTest.java
+++ b/tarantool-pooling/src/test/java/io/tarantool/pool/integration/ConnectionPoolReconnectsTest.java
@@ -77,7 +77,7 @@ public class ConnectionPoolReconnectsTest extends BasePoolTest {
     assertTrue(pool.hasAvailableClients());
     List<IProtoClient> clients = getConnects(pool, "node-a", count1);
     assertTrue(pingClients(clients));
-    assertEquals(count1, getActiveConnectionsCount(tt));
+    waitForActiveConnections(tt, count1);
 
     tt.stop();
     Thread.sleep(1000);
@@ -110,7 +110,7 @@ public class ConnectionPoolReconnectsTest extends BasePoolTest {
         });
 
     assertTrue(pingClients(clients));
-    assertEquals(count1, getActiveConnectionsCount(tt));
+    waitForActiveConnections(tt, count1);
 
     assertEquals(count1, metricsRegistry.get("pool.size").gauge().value());
     assertEquals(count1, metricsRegistry.get("pool.available").gauge().value());


### PR DESCRIPTION
## Summary

PoolEntry had several races between netty IO threads, the HashedWheelTimer heartbeat worker, and reconnect calls, manifesting as ABBA deadlocks, NPEs on inline connect failures, and leaked connections after a KILL/reconnect cycle in CI.

### Production fixes

**PoolEntry**
- Synchronize state mutations; mark fields `volatile`/`AtomicBoolean` for cross-thread visibility.
- Narrow monitor critical sections to field mutations; call `client.close()` and `emit()` outside the monitor to break the ABBA deadlock between `ConnectionImpl` and `PoolEntry` monitors that hung `DistributingRoundRobinBalancerTest`.
- Return the local chain future from `internalConnect()` so an inline connect failure cannot leave the caller observing a null `connectFuture` after `handleConnectError()` nulls it for reconnect.
- Keep `client.close()` in `shutdown()` on every invocation (idempotent via `closeChannel` no-op) but guard only the `onConnectionClosed` emit, so a KILL-then-reconnect cycle cannot leak the new connection when its auth/ping subsequently fails.
- Serialize `connectAfter()` reconnect-task scheduling to avoid double scheduling; double-check `connectFuture` in `internalConnect()` to return the in-flight future instead of starting a new connect.

**IProtoClientPoolImpl**
- Synchronize `forEach()` on `connectionPoolLock` to avoid CME under concurrent `setGroups()`.

### Test fixes

- Wait for `box.stat.net().CONNECTIONS.current` to stabilise in `BasePoolTest.getActiveConnectionsCount`: the IProto worker updates it asynchronously, so a single read often lags by 5-15 connections when 20+ are opened in a burst.
- Collapse the wait-for-stable Lua script to a single line so tarantool emits one YAML document (SnakeYAML rejects multi-document streams).
- Wait for the active connection count to reach the expected value in `ConnectionPoolReconnectsTest` post-reconnect assertions via a new `waitForActiveConnections()` helper.

I haven't forgotten about:
- [x] Tests
- [x] Changelog
- [ ] Documentation
  - [x] JavaDoc was written
- [x] Commit messages comply with the [guideline](https://www.tarantool.io/en/doc/latest/dev_guide/developer_guidelines/#how-to-write-a-commit-message)
- [x] Cleanup the code for review. See [checklist](https://github.com/tarantool/cartridge-java/blob/master/docs/review-checklist.md)

Related issues: