### PR TITLE
fix(pooling): make active-connection assertions race-free

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@
 ### Bug fixes
 
 - Fix flaky `ConnectionPoolReconnectsTest` assertions on active connection count by polling 
-  `box.stat.net().CONNECTIONS.current` from Lua until the value stabilizes, instead of relying on a single read 
-  that races with the IProto worker
+  `box.stat.net().CONNECTIONS.current` from Lua until it holds the same value across 
+  5 consecutive reads at 100ms intervals, instead of a single read that races with the IProto worker
 
 ### Testcontainers
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,21 @@
 
 - Add `tarantool-spring-data-40` module with support for Spring Boot 4.0.x and Spring Data 4.0.x
 
+### Bug fixes
+
+- Fix flaky `ConnectionPoolReconnectsTest` assertions on active connection count by polling 
+  `box.stat.net().CONNECTIONS.current` from Lua until the value stabilizes, instead of relying on a single read 
+  that races with the IProto worker
+
 ### Testcontainers
 
 - Add TQE 3.x (message-queue-ee 3.x) integration on top of the
   existing TQE 2.x support; consolidate the TQE 2.x / 3.x test
   surface into a single parameterized suite.
-- Add constructor/builder parameters to supply the initial Lua script as a string or as a file path, and optional additional script paths copied into the container data directory (`Tarantool2Container`, `CartridgeClusterContainer`, `VshardClusterContainer`); simplify bundled `server.lua` accordingly.
+- Add constructor/builder parameters to supply the initial Lua script as a string or as a file path, 
+  and optional additional script paths copied into the container data directory 
+  (`Tarantool2Container`, `CartridgeClusterContainer`, `VshardClusterContainer`); 
+  simplify bundled `server.lua` accordingly.
 - Upgrade TQE to v3.5.0.
 - Extract `ObjectMapper` to a static field in the test `tdg.Utils` helper to avoid recreating it on every `sendUsers`/`getUsers` call.
 
@@ -21,8 +30,10 @@
 
 ### Documentation
 
-- Document supported Java types for Tarantool data mapping in `tuple_pojo_mapping` docs (RU/EN), including Tarantool extension types (`decimal`, `uuid`, `datetime`, `interval`, `tuple`) and related mapping notes.
-- Document Jackson MsgPack deserialization: integers, `bin`/`str` vs `byte[]`/`String`, floating-point vs `decimal`; reference `jackson-dataformat-msgpack` for defaults and type coercion.
+- Document supported Java types for Tarantool data mapping in `tuple_pojo_mapping` docs (RU/EN), 
+  including Tarantool extension types (`decimal`, `uuid`, `datetime`, `interval`, `tuple`) and related mapping notes.
+- Document Jackson MsgPack deserialization: integers, `bin`/`str` vs `byte[]`/`String`, floating-point vs `decimal`; 
+  reference `jackson-dataformat-msgpack` for defaults and type coercion.
 
 ### Dependencies
 - Updated dependencies:

--- a/tarantool-pooling/src/test/java/io/tarantool/pool/integration/BasePoolTest.java
+++ b/tarantool-pooling/src/test/java/io/tarantool/pool/integration/BasePoolTest.java
@@ -94,15 +94,21 @@ public class BasePoolTest {
 
   protected int getActiveConnectionsCount(TarantoolContainer<?> tt) {
     try {
-      // box.stat.net().CONNECTIONS.current is updated asynchronously by the IProto worker;
-      // the loop's fiber.sleep lets it drain pending connections before we read.
+      // IProto worker updates CONNECTIONS.current asynchronously; require 5 consecutive equal
+      // reads at 100ms intervals before trusting the value (100 iters = 10s safety net).
       String lua =
           "local last = box.stat.net().CONNECTIONS.current;"
-              + " for i = 1, 50 do"
-              + " require('fiber').sleep(0.05);"
+              + " local stable = 1;"
+              + " for i = 1, 100 do"
+              + " require('fiber').sleep(0.1);"
               + " local cur = box.stat.net().CONNECTIONS.current;"
-              + " if cur == last then return cur - 1 end;"
+              + " if cur == last then"
+              + " stable = stable + 1;"
+              + " if stable >= 5 then return cur - 1 end;"
+              + " else"
               + " last = cur;"
+              + " stable = 1;"
+              + " end;"
               + " end;"
               + " return last - 1";
       List<? extends Object> result = TarantoolContainerClientHelper.executeCommandDecoded(tt, lua);
@@ -116,22 +122,8 @@ public class BasePoolTest {
     return getActiveConnectionsCount(tt) - baseline;
   }
 
-  /**
-   * Retries {@link #getActiveConnectionsCount} until it equals {@code expected} — see there for why
-   * a single read is unreliable.
-   *
-   * @param tt the Tarantool container under test
-   * @param expected the expected number of active connections
-   */
   protected void waitForActiveConnections(TarantoolContainer<?> tt, int expected) {
-    try {
-      waitFor(
-          "Active connections count never reached " + expected,
-          Duration.ofSeconds(10),
-          () -> assertEquals(expected, getActiveConnectionsCount(tt)));
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
+    assertEquals(expected, getActiveConnectionsCount(tt));
   }
 
   protected MeterRegistry createMetricsRegistry() {

--- a/tarantool-pooling/src/test/java/io/tarantool/pool/integration/BasePoolTest.java
+++ b/tarantool-pooling/src/test/java/io/tarantool/pool/integration/BasePoolTest.java
@@ -15,6 +15,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ThreadLocalRandom;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import io.micrometer.core.instrument.Counter;
@@ -93,10 +94,19 @@ public class BasePoolTest {
 
   protected int getActiveConnectionsCount(TarantoolContainer<?> tt) {
     try {
-      List<? extends Object> result =
-          TarantoolContainerClientHelper.executeCommandDecoded(
-              tt, "return box.stat.net().CONNECTIONS.current");
-      return (Integer) result.get(0) - 1;
+      // box.stat.net().CONNECTIONS.current is updated asynchronously by the IProto worker;
+      // the loop's fiber.sleep lets it drain pending connections before we read.
+      String lua =
+          "local last = box.stat.net().CONNECTIONS.current;"
+              + " for i = 1, 50 do"
+              + " require('fiber').sleep(0.05);"
+              + " local cur = box.stat.net().CONNECTIONS.current;"
+              + " if cur == last then return cur - 1 end;"
+              + " last = cur;"
+              + " end;"
+              + " return last - 1";
+      List<? extends Object> result = TarantoolContainerClientHelper.executeCommandDecoded(tt, lua);
+      return (Integer) result.get(0);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
@@ -104,6 +114,24 @@ public class BasePoolTest {
 
   protected int getActiveConnectionsCountDelta(TarantoolContainer<?> tt, int baseline) {
     return getActiveConnectionsCount(tt) - baseline;
+  }
+
+  /**
+   * Retries {@link #getActiveConnectionsCount} until it equals {@code expected} — see there for why
+   * a single read is unreliable.
+   *
+   * @param tt the Tarantool container under test
+   * @param expected the expected number of active connections
+   */
+  protected void waitForActiveConnections(TarantoolContainer<?> tt, int expected) {
+    try {
+      waitFor(
+          "Active connections count never reached " + expected,
+          Duration.ofSeconds(10),
+          () -> assertEquals(expected, getActiveConnectionsCount(tt)));
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
   }
 
   protected MeterRegistry createMetricsRegistry() {

--- a/tarantool-pooling/src/test/java/io/tarantool/pool/integration/ConnectionPoolReconnectsTest.java
+++ b/tarantool-pooling/src/test/java/io/tarantool/pool/integration/ConnectionPoolReconnectsTest.java
@@ -77,7 +77,7 @@ public class ConnectionPoolReconnectsTest extends BasePoolTest {
     assertTrue(pool.hasAvailableClients());
     List<IProtoClient> clients = getConnects(pool, "node-a", count1);
     assertTrue(pingClients(clients));
-    assertEquals(count1, getActiveConnectionsCount(tt));
+    waitForActiveConnections(tt, count1);
 
     tt.stop();
     Thread.sleep(1000);
@@ -110,7 +110,7 @@ public class ConnectionPoolReconnectsTest extends BasePoolTest {
         });
 
     assertTrue(pingClients(clients));
-    assertEquals(count1, getActiveConnectionsCount(tt));
+    waitForActiveConnections(tt, count1);
 
     assertEquals(count1, metricsRegistry.get("pool.size").gauge().value());
     assertEquals(count1, metricsRegistry.get("pool.available").gauge().value());


### PR DESCRIPTION
**Что сделано**

  Проверка на количество активных соединений в интеграционных тестах tarantool-pooling теперь дожидаются стабилизации счётчика на стороне Tarantool, а не читают его один раз.

**Зачем**

  box.stat.net().CONNECTIONS.current обновляется асинхронно. Старый getActiveConnectionsCount делал единственный executeCommandDecoded сразу после старта клиентов.
  Под нагрузкой CI значение кол-ва активных соединений часто оказывалось на одно больше или меньше реального, как следствие ConnectionPoolReconnectsTest периодически падал с ошибкой expected: <count1> but was: <count1 - 1> (или ниже).

**Изменения**

  - BasePoolTest#getActiveConnectionsCount теперь выполняет короткий ограниченный Lua-цикл: перечитывает счётчик и возвращает значение, только когда два чтения подряд совпали. Если счётчик всё время меняется, через 50 × 50 миллисекунд возвращается последнее значение.
  - Новый хелпер BasePoolTest#waitForActiveConnections(tt, expected) для тестов, которым нужно точное кол-во активных соединений.
  - В ConnectionPoolReconnectsTest два assertEquals(count1, getActiveConnectionsCount(tt)) заменены на waitForActiveConnections(tt, count1).

I haven't forgotten about:
- [x] Tests
- [x] Changelog
- [ ] Documentation
  - [ ] JavaDoc was written
- [x] Commit messages comply with the [guideline](https://www.tarantool.io/en/doc/latest/dev_guide/developer_guidelines/#how-to-write-a-commit-message)
- [x] Cleanup the code for review. See [checklist](https://github.com/tarantool/cartridge-java/blob/master/docs/review-checklist.md)

Related issues:
<!-- Needed for #123 -->
<!-- See also #456, #789 -->
<!-- Part of #123 -->
<!-- Closes #456 -->
