### PR TITLE
ci: migrate workflows from self-hosted to GitHub-hosted runners

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-20.04-self-hosted
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-20.04-self-hosted
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   publish-snapshot:
     if: "!contains(github.event.head_commit.message, '[maven-release-plugin]')"
-    runs-on: ubuntu-20.04-self-hosted
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/spotless.yml
+++ b/.github/workflows/spotless.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   spotless-check:
-    runs-on: ubuntu-20.04-self-hosted
+    runs-on: ubuntu-22.04
     continue-on-error: true
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ env:
 
 jobs:
   tests-unit:
-    runs-on: ubuntu-20.04-self-hosted
+    runs-on: ubuntu-22.04
     timeout-minutes: 40
     steps:
       - uses: actions/checkout@v6
@@ -64,7 +64,7 @@ jobs:
       #    retention-days: 1
 
   tests-box-integration:
-    runs-on: ubuntu-20.04-self-hosted
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -89,9 +89,6 @@ jobs:
 
       - name: Set locale environment variables
         run: |
-          # Замена зеркала в sources.list
-          sudo sed -i "s|archive.ubuntu.com|mirror.yandex.ru|g" /etc/apt/sources.list
-          sudo sed -i "s|security.ubuntu.com|mirror.yandex.ru|g" /etc/apt/sources.list
           
           sudo apt-get update
           sudo apt-get install -y locales
@@ -123,7 +120,7 @@ jobs:
       #    retention-days: 1
 
   tests-crud-integration:
-    runs-on: ubuntu-20.04-self-hosted
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -144,9 +141,6 @@ jobs:
 
       - name: Set locale environment variables
         run: |
-          # Замена зеркала в sources.list
-          sudo sed -i "s|archive.ubuntu.com|mirror.yandex.ru|g" /etc/apt/sources.list
-          sudo sed -i "s|security.ubuntu.com|mirror.yandex.ru|g" /etc/apt/sources.list
           
           sudo apt-get update
           sudo apt-get install -y locales

--- a/.github/workflows/unused/java-doc.yml
+++ b/.github/workflows/unused/java-doc.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   javadoc-build:
-    runs-on: ubuntu-20.04-self-hosted
+    runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6

--- a/tarantool-core/pom.xml
+++ b/tarantool-core/pom.xml
@@ -10,6 +10,7 @@
     <license.header.file>${project.parent.basedir}/LICENSE_HEADER.txt</license.header.file>
   </properties>
 
+
   <parent>
     <groupId>io.tarantool</groupId>
     <artifactId>tarantool-java-sdk</artifactId>


### PR DESCRIPTION
TDGClientTest queried spaces right after cluster.start(), which only waits for the containers to come up. The TDG data model (and therefore the User/person spaces) is applied asynchronously afterwards, so on slower runners the first queries hit a not-yet-created space and failed with "attempt to index ... 'space' (a nil value)". Wait for the model in @BeforeAll by probing both spaces via retryUntilSuccess before the tests run.

<!-- What has been done? Why? What problem is being solved? -->


I haven't forgotten about:
- [ ] Tests
- [ ] Changelog
- [ ] Documentation
  - [ ] JavaDoc was written
- [ ] Commit messages comply with the [guideline](https://www.tarantool.io/en/doc/latest/dev_guide/developer_guidelines/#how-to-write-a-commit-message)
- [x] Cleanup the code for review. See [checklist](https://github.com/tarantool/cartridge-java/blob/master/docs/review-checklist.md)

Related issues:
<!-- Needed for #123 -->
<!-- See also #456, #789 -->
<!-- Part of #123 -->
<!-- Closes #456 -->
