### PR TITLE
test(tdg): await data model readiness in TDGClientTest

### DIFF
--- a/tarantool-client/src/test/java/io/tarantool/client/integration/tdg/TDGClientTest.java
+++ b/tarantool-client/src/test/java/io/tarantool/client/integration/tdg/TDGClientTest.java
@@ -16,12 +16,14 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.rnorth.ducttape.unreliables.Unreliables;
 import org.testcontainers.containers.tdg.cluster.TDGCluster;
 import org.testcontainers.containers.tdg.cluster.TDGClusterImpl;
 import org.testcontainers.containers.tdg.configuration.TDGConfigurator;
@@ -40,6 +42,8 @@ class TDGClientTest {
   private static final DockerImageName TDG_IMAGE =
       DockerImageName.parse(
           System.getenv().getOrDefault("TARANTOOL_REGISTRY", "") + "tdg2:2.11.5-0-geff8adb3");
+
+  private static final int MODEL_READINESS_TIMEOUT_SECONDS = 60;
 
   private static final Path ROOT_CONFIG_PATH;
 
@@ -73,6 +77,18 @@ class TDGClientTest {
             .withHost(configurator.core().getValue().iprotoMappedAddress().getHostName())
             .withPort(configurator.core().getValue().iprotoMappedAddress().getPort())
             .build();
+    awaitModelReady();
+  }
+
+  private static void awaitModelReady() {
+    Unreliables.retryUntilSuccess(
+        MODEL_READINESS_TIMEOUT_SECONDS,
+        TimeUnit.SECONDS,
+        () -> {
+          client.space("User").get(1).join();
+          client.space("person").get(1).join();
+          return null;
+        });
   }
 
   @AfterAll


### PR DESCRIPTION
TDGClientTest queried spaces right after cluster.start(), which only waits for the containers to come up. The TDG data model (and therefore the User/person spaces) is applied asynchronously afterwards, so on slower runners the first queries hit a not-yet-created space and failed with "attempt to index ... 'space' (a nil value)". Wait for the model in @BeforeAll by probing both spaces via retryUntilSuccess before the tests run.

<!-- What has been done? Why? What problem is being solved? -->


I haven't forgotten about:
- [ ] Tests
- [ ] Changelog
- [ ] Documentation
  - [ ] JavaDoc was written
- [ ] Commit messages comply with the [guideline](https://www.tarantool.io/en/doc/latest/dev_guide/developer_guidelines/#how-to-write-a-commit-message)
- [ ] Cleanup the code for review. See [checklist](https://github.com/tarantool/cartridge-java/blob/master/docs/review-checklist.md)

Related issues:
<!-- Needed for #123 -->
<!-- See also #456, #789 -->
<!-- Part of #123 -->
<!-- Closes #456 -->
